### PR TITLE
Add `opts.componentDidUpdate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ export default () => (
 #### middleware
 
 ```js
-import {middleware} from 'fusion-react-async';
+import { middleware } from 'fusion-react-async';
 ```
 
 A middleware that adds a `PrepareProvider` to the React tree.
@@ -116,62 +116,63 @@ Consider using [`fusion-react`](https://github.com/fusionjs/fusion-react) instea
 #### split
 
 ```js
-import {split} from 'fusion-react-async';
+import { split } from 'fusion-react-async';
 
-const Component = split({load, LoadingComponent, ErrorComponent});
+const Component = split({ load, LoadingComponent, ErrorComponent });
 ```
 
-- `load: () => Promise` - Required. Load a component asynchronously. Typically, this should make a dynamic `import()` call.
+* `load: () => Promise` - Required. Load a component asynchronously. Typically, this should make a dynamic `import()` call.
   The Fusion compiler takes care of bundling the appropriate code and de-duplicating dependencies. The argument to `import` should be a string literal (not a variable). See [webpack docs](https://webpack.js.org/api/module-methods/#import-) for more information.
-- `LoadingComponent` - Required. A component to be displayed while the asynchronous component hasn't downloaded
-- `ErrorComponent` - Required. A component to be displayed if the asynchronous component could not be loaded
-- `Component` - A placeholder component that can be used in your view which will show the asynchronous component
+* `LoadingComponent` - Required. A component to be displayed while the asynchronous component hasn't downloaded
+* `ErrorComponent` - Required. A component to be displayed if the asynchronous component could not be loaded
+* `Component` - A placeholder component that can be used in your view which will show the asynchronous component
 
 #### prepare
 
 ```js
-import {prepare} from 'fusion-react-async';
+import { prepare } from 'fusion-react-async';
 
-const Component = prepare(element)
+const Component = prepare(element);
 ```
 
-- `Element: React.Element` - Required. A React element created via `React.createElement`
-- `Component: React.Component` - A React component
+* `Element: React.Element` - Required. A React element created via `React.createElement`
+* `Component: React.Component` - A React component
 
 Consider using [`fusion-react`](https://github.com/fusionjs/fusion-react) instead of setting up React manually and calling `prepare` directly, since that package does all of that for you.
 
 The `prepare` function recursively traverses the element rendering tree and awaits the side effects of components decorated with `prepared` (or `dispatched`).
 
-It should be used (and `await`-ed) *before* calling `renderToString` on the server. If any of the side effects throws, `prepare` will also throw.
+It should be used (and `await`-ed) _before_ calling `renderToString` on the server. If any of the side effects throws, `prepare` will also throw.
 
 #### prepared
 
 ```js
-import {prepared} from 'fusion-react-async';
+import { prepared } from 'fusion-react-async';
 
 const hoc = prepared(sideEffect, opts);
 ```
 
-- `sideEffect: : (props: Object, context: Object) => Promise` - Required. when `prepare` is called, `sideEffect` is called (and awaited) before continuing the rendering traversal.
-- `opts: {defer, boundary, componentDidMount, componentWillReceiveProps, forceUpdate, contextTypes}` - Optional
-  - `defer: boolean` - Optional. Defaults to `true`. If the component is deferred, skip the prepare step
-  - `boundary: boolean` - Optional. Defaults to `false`. Stop traversing if the component is defer or boundary
-  - `componentDidMount: boolean` - Optional. Defaults to `true`. On the browser, `sideEffect` is called when the component is mounted.
-  - `componentWillReceiveProps: boolean` - Optional. Defaults to `false`. On the browser, `sideEffect` is called again whenever the component receive props.
-  - `forceUpdate: boolean` - Optional. Defaults to `false`.
-  - `contextTypes: Object` - Optional. Custom React context types to add to the prepared component.
-- `hoc: (Component: React.Component) => React.Component` - A higher-order component that returns a component that awaits for async side effects before rendering
-  - `Component: React.Component` - Required.
+* `sideEffect: : (props: Object, context: Object) => Promise` - Required. when `prepare` is called, `sideEffect` is called (and awaited) before continuing the rendering traversal.
+* `opts: {defer, boundary, componentDidMount, componentWillReceiveProps, forceUpdate, contextTypes}` - Optional
+  * `defer: boolean` - Optional. Defaults to `true`. If the component is deferred, skip the prepare step
+  * `boundary: boolean` - Optional. Defaults to `false`. Stop traversing if the component is defer or boundary
+  * `componentDidMount: boolean` - Optional. Defaults to `true`. On the browser, `sideEffect` is called when the component is mounted.
+  * [TO BE DEPRECATED] `componentWillReceiveProps: boolean` - Optional. Defaults to `false`. On the browser, `sideEffect` is called again whenever the component receive props.
+  * `componentDidUpdate: boolean` - Optional. Defaults to `false`. On the browser, `sideEffect` is called again right after updating occurs.
+  * `forceUpdate: boolean` - Optional. Defaults to `false`.
+  * `contextTypes: Object` - Optional. Custom React context types to add to the prepared component.
+* `hoc: (Component: React.Component) => React.Component` - A higher-order component that returns a component that awaits for async side effects before rendering
+  * `Component: React.Component` - Required.
 
 #### exclude
 
 ```js
-import {exclude} from 'fusion-react-async';
+import { exclude } from 'fusion-react-async';
 
 const NewComponent = exclude(Component);
 ```
 
-- `Component: React.Component` - Required. A component that should not be traversed via `prepare`.
-- `NewComponent: React.Component` - A component that is excluded from `prepare` traversal.
+* `Component: React.Component` - Required. A component that should not be traversed via `prepare`.
+* `NewComponent: React.Component` - A component that is excluded from `prepare` traversal.
 
 Stops `prepare` traversal at `Component`. Useful for optimizing the `prepare` traversal to visit the minimum number of nodes.

--- a/src/prepared.js
+++ b/src/prepared.js
@@ -15,6 +15,7 @@ const prepared = (prepare, opts = {}) => OriginalComponent => {
       defer: false,
       componentDidMount: true,
       componentWillReceiveProps: false,
+      componentDidUpdate: false,
       contextTypes: {},
       forceUpdate: false,
     },
@@ -42,6 +43,12 @@ const prepared = (prepare, opts = {}) => OriginalComponent => {
     componentWillReceiveProps(nextProps, nextContext) {
       if (opts.componentWillReceiveProps) {
         prepare(nextProps, nextContext);
+      }
+    }
+
+    componentDidUpdate() {
+      if (opts.componentDidUpdate) {
+        prepare(this.props, this.context);
       }
     }
 

--- a/src/traverse-exclude.js
+++ b/src/traverse-exclude.js
@@ -11,5 +11,6 @@ import prepared from './prepared.js';
 export default prepared(Promise.resolve(), {
   componentDidMount: false,
   componentWillReceiveProps: false,
+  componentDidUpdate: false,
   defer: true,
 });


### PR DESCRIPTION
`componentWillReceiveProps` is soon going to be deprecated in future versions of react.

The new recommendation for making side-effects when there is a difference between current + previous props is to do so in `componentDidUpdate` (see: https://reactjs.org/docs/react-component.html#componentdidupdate)

When react enables async rendering in future releases of react, this will break lifecycle methods into "render" phase and "commit" phase. Methods in the "render" phase (includes `componentWillReceiveProps`) are meant to be side-effect free as they might be called multiple times.

`componentDidMount` and `componentDidUpdate` are called in the "commit" phase and are the recommended place for side-effects (includes network calls). see: https://reactjs.org/docs/strict-mode.html#detecting-unexpected-side-effects

twitter thread with more context: https://twitter.com/ken_wheeler/status/983022255746768897?s=20

The current change is BC since we are only adding a new feature. (see #87 )