### PR TITLE
Improve Flow type definitions for exported functions

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,14 +1,15 @@
 [ignore]
 .*/node_modules/.*[^(package)]\.json$
+<PROJECT_ROOT>/dist/.*
 
 [include]
 ./src/
 
 [libs]
+./node_modules/fusion-core/flow-typed
 
 [lints]
 
 [options]
-suppress_comment= \\(.\\|\n\\)*\\$FlowIgnore
 
 [strict]

--- a/flow-typed/globals.js
+++ b/flow-typed/globals.js
@@ -1,0 +1,10 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+declare var __NODE__: boolean;
+declare var __BROWSER__: boolean;

--- a/flow-typed/tape-cup_v4.x.x.js
+++ b/flow-typed/tape-cup_v4.x.x.js
@@ -1,0 +1,105 @@
+/* eslint-disable  */
+
+declare type tape$TestOpts = {
+  skip: boolean,
+  timeout?: number,
+} | {
+  skip?: boolean,
+  timeout: number,
+};
+
+declare type tape$TestCb = (t: tape$Context) => mixed;
+declare type tape$TestFn = (a: string | tape$TestOpts | tape$TestCb, b?: tape$TestOpts | tape$TestCb, c?: tape$TestCb) => void;
+
+declare interface tape$Context {
+  fail(msg?: string): void,
+  pass(msg?: string): void,
+
+  error(err: mixed, msg?: string): void,
+  ifError(err: mixed, msg?: string): void,
+  ifErr(err: mixed, msg?: string): void,
+  iferror(err: mixed, msg?: string): void,
+
+  ok(value: mixed, msg?: string): void,
+  true(value: mixed, msg?: string): void,
+  assert(value: mixed, msg?: string): void,
+
+  notOk(value: mixed, msg?: string): void,
+  false(value: mixed, msg?: string): void,
+  notok(value: mixed, msg?: string): void,
+
+  // equal + aliases
+  equal(actual: mixed, expected: mixed, msg?: string): void,
+  equals(actual: mixed, expected: mixed, msg?: string): void,
+  isEqual(actual: mixed, expected: mixed, msg?: string): void,
+  is(actual: mixed, expected: mixed, msg?: string): void,
+  strictEqual(actual: mixed, expected: mixed, msg?: string): void,
+  strictEquals(actual: mixed, expected: mixed, msg?: string): void,
+
+  // notEqual + aliases
+  notEqual(actual: mixed, expected: mixed, msg?: string): void,
+  notEquals(actual: mixed, expected: mixed, msg?: string): void,
+  notStrictEqual(actual: mixed, expected: mixed, msg?: string): void,
+  notStrictEquals(actual: mixed, expected: mixed, msg?: string): void,
+  isNotEqual(actual: mixed, expected: mixed, msg?: string): void,
+  isNot(actual: mixed, expected: mixed, msg?: string): void,
+  not(actual: mixed, expected: mixed, msg?: string): void,
+  doesNotEqual(actual: mixed, expected: mixed, msg?: string): void,
+  isInequal(actual: mixed, expected: mixed, msg?: string): void,
+
+  // deepEqual + aliases
+  deepEqual(actual: mixed, expected: mixed, msg?: string): void,
+  deepEquals(actual: mixed, expected: mixed, msg?: string): void,
+  isEquivalent(actual: mixed, expected: mixed, msg?: string): void,
+  same(actual: mixed, expected: mixed, msg?: string): void,
+
+  // notDeepEqual
+  notDeepEqual(actual: mixed, expected: mixed, msg?: string): void,
+  notEquivalent(actual: mixed, expected: mixed, msg?: string): void,
+  notDeeply(actual: mixed, expected: mixed, msg?: string): void,
+  notSame(actual: mixed, expected: mixed, msg?: string): void,
+  isNotDeepEqual(actual: mixed, expected: mixed, msg?: string): void,
+  isNotDeeply(actual: mixed, expected: mixed, msg?: string): void,
+  isNotEquivalent(actual: mixed, expected: mixed, msg?: string): void,
+  isInequivalent(actual: mixed, expected: mixed, msg?: string): void,
+
+  // deepLooseEqual
+  deepLooseEqual(actual: mixed, expected: mixed, msg?: string): void,
+  looseEqual(actual: mixed, expected: mixed, msg?: string): void,
+  looseEquals(actual: mixed, expected: mixed, msg?: string): void,
+
+  // notDeepLooseEqual
+  notDeepLooseEqual(actual: mixed, expected: mixed, msg?: string): void,
+  notLooseEqual(actual: mixed, expected: mixed, msg?: string): void,
+  notLooseEquals(actual: mixed, expected: mixed, msg?: string): void,
+
+  throws(fn: Function, expected?: RegExp | Function, msg?: string): void,
+  doesNotThrow(fn: Function, expected?: RegExp | Function, msg?: string): void,
+
+  timeoutAfter(ms: number): void,
+
+  skip(msg?: string): void,
+  plan(n: number): void,
+  onFinish(fn: Function): void,
+  end(): void,
+  comment(msg: string): void,
+  test: tape$TestFn,
+}
+
+declare module 'tape-cup' {
+  declare type TestHarness = Tape;
+  declare type StreamOpts = {
+    objectMode?: boolean,
+  };
+
+  declare type Tape = {
+    (a: string | tape$TestOpts | tape$TestCb, b?: tape$TestCb | tape$TestOpts, c?: tape$TestCb, ...rest: Array<void>): void,
+    test: tape$TestFn,
+    skip: (name: string, cb?: tape$TestCb) => void,
+    createHarness: () => TestHarness,
+    createStream: (opts?: StreamOpts) => stream$Readable,
+    only: (a: string | tape$TestOpts | tape$TestCb, b?: tape$TestCb | tape$TestOpts, c?: tape$TestCb, ...rest: Array<void>) => void,
+  };
+
+  declare module.exports: Tape;
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "1.2.1",
   "description": "Prepare you app state for async rendering",
   "repository": "fusionjs/fusion-react-async",
-  "files": ["dist", "src"],
+  "files": [
+    "dist",
+    "src"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.es.js",
   "browser": {
@@ -27,6 +30,7 @@
     "test": "npm run build-test && npm run just-test"
   },
   "dependencies": {
+    "fusion-core": "^1.2.2",
     "prop-types": "^15.5.8",
     "react-is": "^16.3.1"
   },
@@ -52,7 +56,8 @@
   },
   "peerDependencies": {
     "react": "14.x - 16.x",
-    "react-dom": "14.x - 16.x"
+    "react-dom": "14.x - 16.x",
+    "fusion-core": "^1.0.0"
   },
   "engines": {
     "node": ">= 8.9.0"

--- a/src/__tests__/__node__/context.node.js
+++ b/src/__tests__/__node__/context.node.js
@@ -1,3 +1,11 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
 import tape from 'tape-cup';
 import React from 'react';
 import {renderToString} from 'react-dom/server';
@@ -5,12 +13,12 @@ import Provider from '../../prepare-provider';
 import {prepare} from '../../index.js';
 
 tape('Handling context', async t => {
-  class Child extends React.Component {
+  class Child extends React.Component<any, any> {
     static contextTypes = {
       field: () => {},
     };
 
-    constructor(props) {
+    constructor(props: *) {
       super(props);
     }
 
@@ -19,7 +27,7 @@ tape('Handling context', async t => {
     }
   }
 
-  class Parent extends React.Component {
+  class Parent extends React.Component<any, any> {
     static childContextTypes = {
       field: () => {},
     };

--- a/src/__tests__/__node__/prepare-context.node.js
+++ b/src/__tests__/__node__/prepare-context.node.js
@@ -2,6 +2,8 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
  */
 
 /* eslint-disable react/no-multi-comp */
@@ -13,7 +15,7 @@ tape('Preparing a sync app passing through context', t => {
   let numConstructors = 0;
   let numRenders = 0;
   let numChildRenders = 0;
-  class SimpleComponent extends Component {
+  class SimpleComponent extends Component<any, any> {
     constructor(props, context) {
       super(props, context);
       t.equal(

--- a/src/__tests__/__node__/prepare-render.node.js
+++ b/src/__tests__/__node__/prepare-render.node.js
@@ -2,6 +2,8 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
  */
 
 /* eslint-disable react/no-multi-comp */
@@ -17,7 +19,7 @@ tape('Preparing a sync app', t => {
   let numConstructors = 0;
   let numRenders = 0;
   let numChildRenders = 0;
-  class SimpleComponent extends Component {
+  class SimpleComponent extends Component<any> {
     constructor(props, context) {
       super(props, context);
       t.equal(
@@ -51,7 +53,7 @@ tape('Preparing a sync app with nested children', t => {
   let numConstructors = 0;
   let numRenders = 0;
   let numChildRenders = 0;
-  class SimpleComponent extends Component {
+  class SimpleComponent extends Component<any> {
     constructor(props, context) {
       super(props, context);
       t.equal(
@@ -134,7 +136,7 @@ tape('Preparing an async app', t => {
   let numRenders = 0;
   let numChildRenders = 0;
   let numPrepares = 0;
-  class SimpleComponent extends Component {
+  class SimpleComponent extends Component<any> {
     constructor(props, context) {
       super(props, context);
       t.equal(
@@ -179,7 +181,7 @@ tape('Preparing an async app with nested asyncs', t => {
   let numRenders = 0;
   let numChildRenders = 0;
   let numPrepares = 0;
-  class SimpleComponent extends Component {
+  class SimpleComponent extends Component<any> {
     constructor(props, context) {
       super(props, context);
       t.equal(
@@ -236,7 +238,7 @@ tape('Preparing an app with sibling async components', t => {
   let numRenders = 0;
   let numChildRenders = 0;
   let numPrepares = 0;
-  class SimpleComponent extends Component {
+  class SimpleComponent extends Component<any> {
     constructor(props, context) {
       super(props, context);
       t.equal(
@@ -299,7 +301,7 @@ tape('Rendering a component triggers componentWillMount before render', t => {
   const orderedMethodCalls = [];
   const orderedChildMethodCalls = [];
 
-  class SimpleComponent extends Component {
+  class SimpleComponent extends Component<any> {
     componentWillMount() {
       orderedMethodCalls.push('componentWillMount');
     }
@@ -310,7 +312,7 @@ tape('Rendering a component triggers componentWillMount before render', t => {
     }
   }
 
-  class SimpleChildComponent extends Component {
+  class SimpleChildComponent extends Component<any> {
     componentWillMount() {
       orderedChildMethodCalls.push('componentWillMount');
     }
@@ -336,7 +338,7 @@ tape('Preparing an async app with componentWillReceiveProps option', t => {
   let numRenders = 0;
   let numChildRenders = 0;
   let numPrepares = 0;
-  class SimpleComponent extends Component {
+  class SimpleComponent extends Component<any> {
     constructor(props, context) {
       super(props, context);
       t.equal(
@@ -392,7 +394,7 @@ tape('Preparing an async app with componentDidUpdate option', t => {
   let numRenders = 0;
   let numChildRenders = 0;
   let numPrepares = 0;
-  class SimpleComponent extends Component {
+  class SimpleComponent extends Component<any> {
     constructor(props, context) {
       super(props, context);
       t.equal(
@@ -445,6 +447,7 @@ tape('Preparing an async app with componentDidUpdate option', t => {
 
 tape('Preparing a Fragment', t => {
   const app = (
+    // $FlowFixMe
     <React.Fragment>
       <span>1</span>
       <span>2</span>
@@ -476,6 +479,7 @@ tape('Preparing a fragment with async children', t => {
     return Promise.resolve();
   })(SimplePresentational);
   const app = (
+    // $FlowFixMe
     <React.Fragment>
       <AsyncChild data="test" />
       <AsyncChild data="test" />
@@ -491,6 +495,7 @@ tape('Preparing a fragment with async children', t => {
 });
 
 tape('Preparing React.createContext()', t => {
+  // $FlowFixMe
   const {Provider, Consumer} = React.createContext('light');
 
   const app = (
@@ -511,6 +516,7 @@ tape('Preparing React.createContext()', t => {
 });
 
 tape('Preparing React.createContext() with async children', t => {
+  // $FlowFixMe
   const {Provider, Consumer} = React.createContext('light');
 
   let numChildRenders = 0;

--- a/src/__tests__/__node__/split.node.js
+++ b/src/__tests__/__node__/split.node.js
@@ -2,6 +2,8 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
  */
 
 /* eslint-disable react/no-multi-comp */

--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -2,6 +2,8 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
  */
 
 /* eslint-env node */

--- a/src/index.js
+++ b/src/index.js
@@ -2,15 +2,54 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
  */
 
-// @flow
+import * as React from 'react';
+
 import dispatched from './dispatched';
 import prepare from './prepare';
 import prepared from './prepared';
 import split from './split';
 import exclude from './traverse-exclude';
-import middleware from './middleware';
+import middleware from './middleware'; //typed
+
+const prepareTyped: (
+  element: React.Element<any>
+) => Promise<React.ComponentType<any>> = prepare;
+
+const preparedTyped: (
+  sideEffect: (props: Object, context: Object) => Promise<any>,
+  opts?: {
+    defer?: boolean,
+    boundary?: boolean,
+    componentDidMount?: boolean,
+    componentWillReceiveProps?: boolean,
+    componentDidUpdate?: boolean,
+    forceUpdate?: boolean,
+    contextTypes?: Object,
+  }
+) => (
+  Component: React.ComponentType<any>
+) => React.ComponentType<any> = prepared;
+
+const splitTyped: (opts: {
+  load: () => Promise<any>,
+  LoadingComponent: React.ComponentType<any>,
+  ErrorComponent: React.ComponentType<any>,
+}) => React.ComponentType<any> = split;
+
+const excludeTyped: (
+  Component: React.ComponentType<any>
+) => React.ComponentType<any> = exclude;
 
 // TODO(#3): Can we get ride of some of these exports?
-export {dispatched, prepare, prepared, split, exclude, middleware};
+export {
+  dispatched,
+  prepareTyped as prepare,
+  preparedTyped as prepared,
+  splitTyped as split,
+  excludeTyped as exclude,
+  middleware,
+};

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -2,12 +2,17 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
  */
 
 import React from 'react';
+
+import type {Middleware} from 'fusion-core';
+
 import PrepareProvider from './prepare-provider';
 
-export default function(ctx, next) {
+const middleware: Middleware = function(ctx, next) {
   if (__NODE__ && !ctx.element) {
     return next();
   }
@@ -17,4 +22,6 @@ export default function(ctx, next) {
     </PrepareProvider>
   );
   return next();
-}
+};
+
+export default middleware;

--- a/yarn.lock
+++ b/yarn.lock
@@ -671,6 +671,13 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
+accepts@^1.2.2, accepts@^1.3.3:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.5.tgz#eb777df6011723a3b14e8a72c0805c8e86746bd2"
+  dependencies:
+    mime-types "~2.1.18"
+    negotiator "0.6.1"
+
 acorn-dynamic-import@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz#c752bd210bef679501b6c6cb7fc84f8f47158cc4"
@@ -768,6 +775,10 @@ ansi-styles@^3.1.0, ansi-styles@^3.2.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
   dependencies:
     color-convert "^1.9.0"
+
+any-promise@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
 
 anymatch@^1.3.0:
   version "1.3.2"
@@ -1366,9 +1377,24 @@ contains-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
 
+content-disposition@~0.5.0:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
+
+content-type@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
+
 convert-source-map@^1.1.0, convert-source-map@^1.3.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
+
+cookies@~0.7.0:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/cookies/-/cookies-0.7.1.tgz#7c8a615f5481c61ab9f16c833731bcb8f663b99b"
+  dependencies:
+    depd "~1.1.1"
+    keygrip "~1.0.2"
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -1503,15 +1529,15 @@ debug-log@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
 
-debug@^2.2.0, debug@^2.6.8, debug@^2.6.9:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+debug@*, debug@^3.0.1, debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.1, debug@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+debug@^2.2.0, debug@^2.6.8, debug@^2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
 
@@ -1568,12 +1594,20 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
+depd@^1.1.0, depd@~1.1.1, depd@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
+
 des.js@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.0.tgz#c074d2e2aa6a8a9a07dbd61f9a15c2cd83ec8ecc"
   dependencies:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
+
+destroy@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
 
 detect-indent@^4.0.0:
   version "4.0.0"
@@ -1658,6 +1692,10 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
+
+ee-first@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
 electron-to-chromium@^1.3.30:
   version "1.3.34"
@@ -1751,6 +1789,10 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
+error-inject@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/error-inject/-/error-inject-1.0.0.tgz#e2b3d91b54aed672f309d950d154850fa11d4f37"
+
 es-abstract@^1.5.0, es-abstract@^1.6.1, es-abstract@^1.7.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.10.0.tgz#1ecb36c197842a00d8ee4c2dfd8646bb97d60864"
@@ -1820,6 +1862,10 @@ es6-weak-map@^2.0.1:
     es5-ext "^0.10.14"
     es6-iterator "^2.0.1"
     es6-symbol "^3.1.1"
+
+escape-html@~1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -2231,6 +2277,10 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
+fresh@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
+
 fs-exists-sync@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add"
@@ -2278,6 +2328,17 @@ function.prototype.name@^1.0.3:
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+
+fusion-core@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/fusion-core/-/fusion-core-1.2.2.tgz#bfa6bae6ee8df72db08bc1b99452e2336c317c60"
+  dependencies:
+    koa "^2.4.1"
+    koa-compose "^4.0.0"
+    node-mocks-http "^1.6.6"
+    toposort "^1.0.6"
+    ua-parser-js "^0.7.17"
+    uuid "^3.2.1"
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -2505,6 +2566,22 @@ htmlparser2@^3.9.1:
     inherits "^2.0.1"
     readable-stream "^2.0.2"
 
+http-assert@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/http-assert/-/http-assert-1.3.0.tgz#a31a5cf88c873ecbb5796907d4d6f132e8c01e4a"
+  dependencies:
+    deep-equal "~1.0.1"
+    http-errors "~1.6.1"
+
+http-errors@^1.2.8, http-errors@~1.6.1:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.3"
+    setprototypeof "1.1.0"
+    statuses ">= 1.4.0 < 2"
+
 http-signature@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
@@ -2548,7 +2625,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -2666,6 +2743,10 @@ is-fullwidth-code-point@^2.0.0:
 is-function@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
+
+is-generator-function@^1.0.3:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.7.tgz#d2132e529bb0000a7f80794d4bdf5cd5e5813522"
 
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
@@ -2923,6 +3004,10 @@ jsx-ast-utils@^2.0.1:
   dependencies:
     array-includes "^3.0.3"
 
+keygrip@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.0.2.tgz#ad3297c557069dea8bcfe7a4fa491b75c5ddeb91"
+
 kind-of@^3.0.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -2934,6 +3019,56 @@ kind-of@^4.0.0:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
   dependencies:
     is-buffer "^1.1.5"
+
+koa-compose@^3.0.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/koa-compose/-/koa-compose-3.2.1.tgz#a85ccb40b7d986d8e5a345b3a1ace8eabcf54de7"
+  dependencies:
+    any-promise "^1.1.0"
+
+koa-compose@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/koa-compose/-/koa-compose-4.0.0.tgz#2800a513d9c361ef0d63852b038e4f6f2d5a773c"
+
+koa-convert@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/koa-convert/-/koa-convert-1.2.0.tgz#da40875df49de0539098d1700b50820cebcd21d0"
+  dependencies:
+    co "^4.6.0"
+    koa-compose "^3.0.0"
+
+koa-is-json@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/koa-is-json/-/koa-is-json-1.0.0.tgz#273c07edcdcb8df6a2c1ab7d59ee76491451ec14"
+
+koa@^2.4.1:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/koa/-/koa-2.5.0.tgz#b0fbe1e195e43b27588a04fd0be0ddaeca2c154c"
+  dependencies:
+    accepts "^1.2.2"
+    content-disposition "~0.5.0"
+    content-type "^1.0.0"
+    cookies "~0.7.0"
+    debug "*"
+    delegates "^1.0.0"
+    depd "^1.1.0"
+    destroy "^1.0.3"
+    error-inject "~1.0.0"
+    escape-html "~1.0.1"
+    fresh "^0.5.2"
+    http-assert "^1.1.0"
+    http-errors "^1.2.8"
+    is-generator-function "^1.0.3"
+    koa-compose "^4.0.0"
+    koa-convert "^1.2.0"
+    koa-is-json "^1.0.0"
+    mime-types "^2.0.7"
+    on-finished "^2.1.0"
+    only "0.0.2"
+    parseurl "^1.3.0"
+    statuses "^1.2.0"
+    type-is "^1.5.5"
+    vary "^1.0.0"
 
 lazy-cache@^1.0.3:
   version "1.0.4"
@@ -3052,6 +3187,10 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
+media-typer@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
+
 mem@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
@@ -3065,6 +3204,10 @@ memory-fs@^0.4.0, memory-fs@~0.4.1:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
+merge-descriptors@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
+
 merge-source-map@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.1.0.tgz#2fdde7e6020939f70906a68f2d7ae685e4c8c646"
@@ -3076,6 +3219,10 @@ merge-stream@^1.0.1:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"
   dependencies:
     readable-stream "^2.0.1"
+
+methods@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
 micromatch@^2.1.5, micromatch@^2.3.11:
   version "2.3.11"
@@ -3106,11 +3253,15 @@ mime-db@~1.33.0:
   version "1.33.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
 
-mime-types@^2.1.12, mime-types@~2.1.7:
+mime-types@^2.0.7, mime-types@^2.1.12, mime-types@~2.1.18, mime-types@~2.1.7:
   version "2.1.18"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   dependencies:
     mime-db "~1.33.0"
+
+mime@^1.3.4:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -3185,6 +3336,14 @@ nearley@^2.7.10:
     randexp "0.4.6"
     semver "^5.4.1"
 
+negotiator@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
+
+net@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/net/-/net-1.0.2.tgz#d1757ec9a7fb2371d83cf4755ce3e27e10829388"
+
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -3219,6 +3378,21 @@ node-libs-browser@^2.0.0:
     url "^0.11.0"
     util "^0.10.3"
     vm-browserify "0.0.4"
+
+node-mocks-http@^1.6.6:
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/node-mocks-http/-/node-mocks-http-1.6.7.tgz#89f31c12586585c3812e6bd725d417710d7632e3"
+  dependencies:
+    accepts "^1.3.3"
+    depd "^1.1.0"
+    fresh "^0.5.2"
+    merge-descriptors "^1.0.1"
+    methods "^1.1.2"
+    mime "^1.3.4"
+    net "^1.0.2"
+    parseurl "^1.3.1"
+    range-parser "^1.2.0"
+    type-is "^1.6.14"
 
 node-pre-gyp@^0.6.39:
   version "0.6.39"
@@ -3388,6 +3562,12 @@ object.values@^1.0.4:
     function-bind "^1.1.0"
     has "^1.0.1"
 
+on-finished@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
+  dependencies:
+    ee-first "1.1.1"
+
 once@^1.3.0, once@^1.3.3:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -3399,6 +3579,10 @@ onetime@^2.0.0:
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
   dependencies:
     mimic-fn "^1.0.0"
+
+only@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/only/-/only-0.0.2.tgz#2afde84d03e50b9a8edc444e30610a70295edfb4"
 
 optimist@^0.6.1:
   version "0.6.1"
@@ -3503,6 +3687,10 @@ parse5@^3.0.1:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
   dependencies:
     "@types/node" "*"
+
+parseurl@^1.3.0, parseurl@^1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
 
 path-browserify@0.0.0:
   version "0.0.0"
@@ -3714,6 +3902,10 @@ randomfill@^1.0.3:
   dependencies:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
+
+range-parser@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
 rc@^1.1.7:
   version "1.2.5"
@@ -4049,6 +4241,10 @@ setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
 
+setprototypeof@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
+
 sha.js@^2.4.0, sha.js@^2.4.8:
   version "2.4.10"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.10.tgz#b1fde5cd7d11a5626638a07c604ab909cfa31f9b"
@@ -4154,6 +4350,10 @@ sshpk@^1.7.0:
     ecc-jsbn "~0.1.1"
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
+
+"statuses@>= 1.4.0 < 2", statuses@^1.2.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
 
 stream-browserify@^2.0.1:
   version "2.0.1"
@@ -4371,6 +4571,10 @@ to-object-path@^0.3.0:
   dependencies:
     kind-of "^3.0.2"
 
+toposort@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.6.tgz#c31748e55d210effc00fdcdc7d6e68d7d7bb9cec"
+
 tough-cookie@~2.3.0:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
@@ -4401,11 +4605,18 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+type-is@^1.5.5, type-is@^1.6.14:
+  version "1.6.16"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.16.tgz#f89ce341541c672b25ee7ae3c73dee3b2be50194"
+  dependencies:
+    media-typer "0.3.0"
+    mime-types "~2.1.18"
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-ua-parser-js@^0.7.9:
+ua-parser-js@^0.7.17, ua-parser-js@^0.7.9:
   version "0.7.17"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
 
@@ -4474,7 +4685,7 @@ util@0.10.3, util@^0.10.3:
   dependencies:
     inherits "2.0.1"
 
-uuid@^3.0.0:
+uuid@^3.0.0, uuid@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 
@@ -4484,6 +4695,10 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+vary@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
Fixes [#685](https://app.zenhub.com/workspace/o/uber-web/web-platform-tasks/issues/685)

```
#### Problem/Rationale

Fusion.js packages, with the exception of `fusion-core` do not export [libdef](https://flow.org/en/docs/libdefs/) and consumers rely on the Flow type definitions embedded in the source code.  Given this, it is a pain point for consumers when type definitions are missing or incomplete.

We should also strive for full Flow coverage to minimize issues within our own packages.

#### Solution/Change/Deliverable

Two-fold:
* Reach 100% Flow coverage on exported type definitions.
* Strive for 100% Flow coverage internally for each package.
```

<img width="729" alt="screen shot 2018-04-12 at 2 00 16 pm" src="https://user-images.githubusercontent.com/3497835/38704048-e299dd4c-3e59-11e8-9b54-c714558b7fef.png">

(compare to [before](https://user-images.githubusercontent.com/3497835/38704070-f2b5535a-3e59-11e8-8655-6240ee18e675.png))