### PR TITLE
Fix inconsistencies in documentation and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,16 +152,16 @@ import { prepared } from 'fusion-react-async';
 const hoc = prepared(sideEffect, opts);
 ```
 
-* `sideEffect: : (props: Object, context: Object) => Promise` - Required. when `prepare` is called, `sideEffect` is called (and awaited) before continuing the rendering traversal.
+* `sideEffect: (props: Object, context: Object) => Promise` - Required. When `prepare` is called, `sideEffect` is called (and awaited) before continuing the rendering traversal.
 * `opts: {defer, boundary, componentDidMount, componentWillReceiveProps, componentDidUpdate, forceUpdate, contextTypes}` - Optional
-  * `defer: boolean` - Optional. Defaults to `true`. If the component is deferred, skip the prepare step
-  * `boundary: boolean` - Optional. Defaults to `false`. Stop traversing if the component is defer or boundary
+  * `defer: boolean` - Optional. Defaults to `false`. If the component is deferred, skip the prepare step.
+  * `boundary: boolean` - Optional. Defaults to `false`. Stop traversing if the component is defer or boundary.
   * `componentDidMount: boolean` - Optional. Defaults to `true`. On the browser, `sideEffect` is called when the component is mounted.
   * [TO BE DEPRECATED] `componentWillReceiveProps: boolean` - Optional. Defaults to `false`. On the browser, `sideEffect` is called again whenever the component receive props.
   * `componentDidUpdate: boolean` - Optional. Defaults to `false`. On the browser, `sideEffect` is called again right after updating occurs.
   * `forceUpdate: boolean` - Optional. Defaults to `false`.
   * `contextTypes: Object` - Optional. Custom React context types to add to the prepared component.
-* `hoc: (Component: React.Component) => React.Component` - A higher-order component that returns a component that awaits for async side effects before rendering
+* `hoc: (Component: React.Component) => React.Component` - A higher-order component that returns a component that awaits for async side effects before rendering.
   * `Component: React.Component` - Required.
 
 #### exclude

--- a/src/prepared.js
+++ b/src/prepared.js
@@ -11,7 +11,7 @@ import React, {Component} from 'react';
 import {REACT_PREPARE} from './constants';
 
 // $FlowFixMe
-const prepared = (prepare, opts = {}) => OriginalComponent => {
+const prepared = (sideEffect, opts = {}) => OriginalComponent => {
   opts = Object.assign(
     {
       boundary: false,
@@ -25,7 +25,7 @@ const prepared = (prepare, opts = {}) => OriginalComponent => {
     opts
   );
   const prep = {
-    prepare: (...args) => Promise.resolve(prepare(...args)),
+    prepare: (...args) => Promise.resolve(sideEffect(...args)),
     defer: opts.defer,
   };
   // Disable eslint for deprecated componentWillReceiveProps
@@ -39,7 +39,7 @@ const prepared = (prepare, opts = {}) => OriginalComponent => {
     }
     componentDidMount() {
       if (opts.componentDidMount) {
-        Promise.resolve(prepare(this.props, this.context)).then(() => {
+        Promise.resolve(sideEffect(this.props, this.context)).then(() => {
           if (opts.forceUpdate) {
             this.forceUpdate(); // TODO(#10) document
           }
@@ -50,13 +50,13 @@ const prepared = (prepare, opts = {}) => OriginalComponent => {
     // $FlowFixMe
     componentWillReceiveProps(nextProps, nextContext) {
       if (opts.componentWillReceiveProps) {
-        prepare(nextProps, nextContext);
+        sideEffect(nextProps, nextContext);
       }
     }
 
     componentDidUpdate() {
       if (opts.componentDidUpdate) {
-        prepare(this.props, this.context);
+        sideEffect(this.props, this.context);
       }
     }
 


### PR DESCRIPTION
Fixes https://github.com/fusionjs/fusion-react-async/issues/96

Switched documentation default of `defer` to false and also changed the code for `prepared` to reference the first argument as `sideEffect`, matching the documentation, as opposed to `prepare`. 

Using `sideEffect` made the code more readable IMO since there's already a `prepare` source file and different conjugations of the word already used in the same file.